### PR TITLE
⚡ (blocks/inputs) Optimize Prover Inputs generation's preflight to fetch post-state proofs only for deleted account & storage slots

### DIFF
--- a/pkg/ethereum/trie/custom_node_set.go
+++ b/pkg/ethereum/trie/custom_node_set.go
@@ -75,6 +75,11 @@ func NewProvedAccountNodeSet() *ProvedNodeSet {
 	return NewProvedNodeSet(gethcommon.Hash{})
 }
 
+// NewProvedStorageNodeSet creates a new ProvedNodeSet
+func NewProvedStorageNodeSet(addr gethcommon.Address) *ProvedNodeSet {
+	return NewProvedNodeSet(StorageTrieOwner(addr))
+}
+
 // NewProvedNodeSetFromSet creates a new ProvedNodeSet from an existing trienode.NodeSet
 func NewProvedNodeSetFromSet(set *trienode.NodeSet) *ProvedNodeSet {
 	return &ProvedNodeSet{set: set}
@@ -290,7 +295,7 @@ func NodeSetFromStateProofs(stateRoot gethcommon.Hash, accountProofs []*AccountP
 			continue
 		}
 
-		provedStorageNodeSet := NewProvedNodeSet(StorageTrieOwner(accountProof.Address))
+		provedStorageNodeSet := NewProvedStorageNodeSet(accountProof.Address)
 		err := provedStorageNodeSet.AddStorageNodes(
 			accountProof.StorageHash,
 			accountProof.Storage,
@@ -333,7 +338,7 @@ func NodeSetFromStateTransitionProofs(preRoot, postRoot gethcommon.Hash, preProo
 		if accountProof.StorageHash == (gethcommon.Hash{}) {
 			continue
 		}
-		provedStorageNodeSet := NewProvedNodeSet(StorageTrieOwner(accountProof.Address))
+		provedStorageNodeSet := NewProvedStorageNodeSet(accountProof.Address)
 		err := provedStorageNodeSet.AddStorageNodes(
 			accountProof.StorageHash,
 			accountProof.Storage,

--- a/src/blocks/inputs/execute.go
+++ b/src/blocks/inputs/execute.go
@@ -26,15 +26,15 @@ type Executor interface {
 	Execute(ctx context.Context, inputs *ProvableInputs) (*core.ProcessResult, error)
 }
 
-type BaseExecutor struct{}
+type executor struct{}
 
 // NewExecutor creates a new instance of the BaseExecutor.
-func NewExecutor() *BaseExecutor {
-	return &BaseExecutor{}
+func NewExecutor() Executor {
+	return &executor{}
 }
 
 // Execute runs the ProvableBlockInputs data for the EVM prover engine.
-func (e *BaseExecutor) Execute(ctx context.Context, inputs *ProvableInputs) (*core.ProcessResult, error) {
+func (e *executor) Execute(ctx context.Context, inputs *ProvableInputs) (*core.ProcessResult, error) {
 	ctx = tag.WithComponent(ctx, "execute")
 	ctx = tag.WithTags(
 		ctx,
@@ -60,7 +60,7 @@ type executorContext struct {
 	hc      *core.HeaderChain
 }
 
-func (e *BaseExecutor) execute(ctx context.Context, inputs *ProvableInputs) (*core.ProcessResult, error) {
+func (e *executor) execute(ctx context.Context, inputs *ProvableInputs) (*core.ProcessResult, error) {
 	log.LoggerFromContext(ctx).Infof("Process provable execution...")
 
 	execCtx, err := e.prepareContext(ctx, inputs)
@@ -81,7 +81,7 @@ func (e *BaseExecutor) execute(ctx context.Context, inputs *ProvableInputs) (*co
 	return e.execEVM(execCtx, execParams)
 }
 
-func (e *BaseExecutor) prepareContext(ctx context.Context, inputs *ProvableInputs) (*executorContext, error) {
+func (e *executor) prepareContext(ctx context.Context, inputs *ProvableInputs) (*executorContext, error) {
 	log.LoggerFromContext(ctx).Debug("Prepare context...")
 
 	// --- Create necessary database and chain instances ---
@@ -101,7 +101,7 @@ func (e *BaseExecutor) prepareContext(ctx context.Context, inputs *ProvableInput
 	}, nil
 }
 
-func (e *BaseExecutor) preparePreState(ctx *executorContext, inputs *ProvableInputs) error {
+func (e *executor) preparePreState(ctx *executorContext, inputs *ProvableInputs) error {
 	log.LoggerFromContext(ctx.ctx).Info("Prepare pre-state...")
 
 	// -- Preload the ancestors of the block into database ---
@@ -128,7 +128,7 @@ func (e *BaseExecutor) preparePreState(ctx *executorContext, inputs *ProvableInp
 	return nil
 }
 
-func (e *BaseExecutor) prepareExecParams(ctx *executorContext, inputs *ProvableInputs) (*evm.ExecParams, error) {
+func (e *executor) prepareExecParams(ctx *executorContext, inputs *ProvableInputs) (*evm.ExecParams, error) {
 	log.LoggerFromContext(ctx.ctx).Debug("Prepare execution parameters...")
 
 	parentHeader := inputs.Ancestors[0]
@@ -148,7 +148,7 @@ func (e *BaseExecutor) prepareExecParams(ctx *executorContext, inputs *ProvableI
 	}, nil
 }
 
-func (e *BaseExecutor) execEVM(ctx *executorContext, execParams *evm.ExecParams) (*core.ProcessResult, error) {
+func (e *executor) execEVM(ctx *executorContext, execParams *evm.ExecParams) (*core.ProcessResult, error) {
 	log.LoggerFromContext(ctx.ctx).Infof("Execute EVM...")
 
 	res, err := evm.ExecutorWithTags("evm")(evm.ExecutorWithLog()(evm.NewExecutor())).Execute(ctx.ctx, execParams)


### PR DESCRIPTION
## 📝 Description

<!-- Provide a detailed description of your changes and the motivation behind them. -->

Optimize preflight to fetch post-state proofs only for deleted account & keys.

This is a performance improvement that reduces the required number of call to the JSON-RPC remote node during preflight.

## ✅ Solved Issues

Resolves KKRT-43 <!-- Provide references to the relevant issues, if applicable -->

## 🔄 Change

<!-- Tick the type of change introduced by this Pull Request: -->

- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] 🧪 Tests
- [x] 🧹 Chore (e.g., package upgrades, refactor, small perf improvement, typos...)
- [ ] 🤖 CI (e.g. GitHub Workflows, Makefile...)
- [ ] 📚 Documentation
- [ ] Other (please specify):

<!-- Tick if this Pull Request introduce a breaking change -->

- [ ] 💥 Breaking Change

## 💥 Breaking Change (if applicable)

<!-- If this PR introduce breaking changes, describe them here, covering the migration path (e.g., API changes, configuration updates). -->

## 📋 Checklist

<!-- Confirm the following items are completed before submitting your pull request: -->

- [x] I have added tests to cover my changes, if applicable.
- [x] I have updated relevant documentation for my changes.
- [x] I have included references to issues resolved by this Pull Request
- [x] I have set Pull Request label `type.*` and `breaking-change` or `non-breaking-change`
- [ ] I have documented breaking changes and migration path, if applicable

## 📓 Additional Notes

<!-- Include any additional context, considerations, or dependencies relevant to this pull request. -->