### PR TITLE
⚡️ Fetch ancestors at preflight EVM execution time

### DIFF
--- a/pkg/ethereum/database.go
+++ b/pkg/ethereum/database.go
@@ -1,47 +1,12 @@
 package ethereum
 
 import (
-	"context"
-	"fmt"
-
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	gethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
 )
-
-type FetchHeader func(ctx context.Context, hash gethcommon.Hash) (*gethtypes.Header, error)
-
-// FillDBWithAncestors fills an ethdb.Database with the headers of the ancestors of a block
-// The ancestors headers are fetched from a distinct source (e.g. a remote node, an external database...)
-// If an ancestor header is already present in the database, it is not fetched.
-func FillDBWithAncestors(ctx context.Context, db ethdb.Database, fetcher FetchHeader, block *gethtypes.Block, count int) ([]*gethtypes.Header, error) {
-	parentHash := block.ParentHash()
-	parentNumber := block.NumberU64() - 1
-	ancestors := make([]*gethtypes.Header, 0)
-	var err error
-	for i := 0; i < count; i++ {
-		ancestor := rawdb.ReadHeader(db, parentHash, parentNumber)
-		if ancestor == nil {
-			ancestor, err = fetcher(ctx, parentHash)
-			if err != nil {
-				return nil, fmt.Errorf("failed to fetch ancestor header number=%d hash=%d: %w", parentNumber, parentHash, err)
-			}
-
-			if ancestor == nil {
-				break
-			}
-
-			ancestors = append(ancestors, ancestor)
-			rawdb.WriteHeader(db, ancestor)
-		}
-
-		parentHash = ancestor.ParentHash
-		parentNumber--
-	}
-	return ancestors, nil
-}
 
 // WriteCodes fills an ethdb.Database with the provided bytecodes
 func WriteCodes(db ethdb.Database, codes ...[]byte) {

--- a/pkg/ethereum/database_test.go
+++ b/pkg/ethereum/database_test.go
@@ -1,74 +1,12 @@
 package ethereum
 
 import (
-	"context"
-	"math/big"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/core/rawdb"
-	gethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
-	rpcmock "github.com/kkrt-labs/kakarot-controller/pkg/ethereum/rpc/mock"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/mock/gomock"
 )
-
-func TestFillDBWithAncestors(t *testing.T) {
-	// Generate 50 fake ancestor headers
-	count := 50
-	blockNumber := big.NewInt(260)
-	fakeAncestors := make([]*gethtypes.Header, count)
-	ancestorHash := crypto.Keccak256Hash([]byte("first-ancestor"))
-	for i := (count - 1); i >= 0; i-- {
-		fakeAncestors[i] = &gethtypes.Header{
-			Number:     big.NewInt(int64(blockNumber.Uint64() - uint64(i) - 1)),
-			Root:       crypto.Keccak256Hash([]byte{byte(i)}),
-			ParentHash: ancestorHash,
-		}
-		ancestorHash = fakeAncestors[i].Hash()
-	}
-
-	// Generate block with the latest ancestor as parent
-	block := gethtypes.NewBlockWithHeader(&gethtypes.Header{
-		Number:     blockNumber,
-		Root:       crypto.Keccak256Hash([]byte{byte(count)}),
-		ParentHash: fakeAncestors[0].Hash(),
-	})
-
-	// Prepare a mock RPC client with the fake ancestors
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	remote := rpcmock.NewMockClient(ctrl)
-	for i := 0; i < count; i++ {
-		remote.EXPECT().
-			HeaderByHash(gomock.Any(), fakeAncestors[i].Hash()).
-			Return(fakeAncestors[i], nil)
-	}
-
-	// Execute hook
-	db := rawdb.NewMemoryDatabase()
-	ancestors, err := FillDBWithAncestors(context.Background(), db, remote.HeaderByHash, block, count)
-	require.NoError(t, err)
-
-	// Verify that the ancestors were loaded to chain correctly
-	parentHash := block.ParentHash()
-	parentNumber := block.NumberU64() - 1
-	for i := 0; i < count; i++ {
-		ancestor := rawdb.ReadHeader(db, parentHash, parentNumber)
-		require.NotNil(t, ancestor, "Expected ancestor %v to be non nil", i)
-		assert.Equal(t, fakeAncestors[i].Root, ancestor.Root, "Expected ancestor %v root to be correct", i)
-		parentHash = ancestor.ParentHash
-		parentNumber--
-	}
-
-	// Verify that the return ancestors are correct
-	assert.Len(t, ancestors, count, "Expected 256 ancestors to be loaded")
-	for i, ancestor := range ancestors {
-		assert.Equal(t, fakeAncestors[i], ancestor, "Expected ancestor %v to be correct", i)
-	}
-}
 
 func TestFillDBWithBytecode(t *testing.T) {
 	db := rawdb.NewMemoryDatabase()

--- a/pkg/ethereum/ethdb/rpcdb/rpc_hacked_db.go
+++ b/pkg/ethereum/ethdb/rpcdb/rpc_hacked_db.go
@@ -1,0 +1,70 @@
+package rpcdb
+
+import (
+	"context"
+	"encoding/binary"
+
+	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/kkrt-labs/kakarot-controller/pkg/ethereum/rpc"
+)
+
+// Database wraps an ethdb.Database and fetches missing headers from a remote RPC server.
+type Database struct {
+	ethdb.Database
+	remote rpc.Client
+}
+
+// Hack returns a new Database that fetches missing headers from the remote RPC server.
+func Hack(db ethdb.Database, remote rpc.Client) *Database {
+	return &Database{
+		Database: db,
+		remote:   remote,
+	}
+}
+
+// decodeHeaderNumberAndHash decodes the header number and hash given a Geth ethdb database key.
+// It returns the header number, hash, and a boolean indicating if the key is a header key.
+func decodeHeaderNumberAndHash(key []byte) (uint64, gethcommon.Hash, bool) {
+	if string(key[0]) != "h" || len(key) != 41 {
+		return 0, gethcommon.Hash{}, false
+	}
+
+	return binary.BigEndian.Uint64(key[1:9]), gethcommon.BytesToHash(key[9:41]), true
+}
+
+// Get retrieves the value for a key.
+// It intercepts the key to check if it is a header key.
+// - If the key is a header key, it fetches the header from the remote RPC server.
+// - Otherwise, it calls the underlying ethdb.Database.Get method.
+func (db *Database) Get(key []byte) ([]byte, error) {
+	// Decode the header number and hash from the key
+	_, hash, ok := decodeHeaderNumberAndHash(key)
+	if !ok {
+		return db.Database.Get(key)
+	}
+
+	// Fetch the header from the remote RPC server
+	// Note: We use the context.TODO() because the ethdb.Database.Get method does not accept a context.
+	header, err := db.remote.HeaderByHash(context.TODO(), hash)
+	if err != nil {
+		return nil, err
+	}
+
+	// Encode the header to RLP
+	b, err := rlp.EncodeToBytes(header)
+	if err != nil {
+		return nil, err
+	}
+
+	return b, nil
+}
+
+// Has checks if the database has a key.
+func (db *Database) Has(key []byte) (bool, error) {
+	if _, err := db.Get(key); err != nil {
+		return false, nil
+	}
+	return true, nil
+}

--- a/pkg/ethereum/ethdb/rpcdb/rpc_hacked_db_test.go
+++ b/pkg/ethereum/ethdb/rpcdb/rpc_hacked_db_test.go
@@ -1,0 +1,92 @@
+package rpcdb
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math/big"
+	"testing"
+
+	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	gethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rlp"
+	rpcmock "github.com/kkrt-labs/kakarot-controller/pkg/ethereum/rpc/mock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// Below var and methods are taken from Geth
+var headerPrefix = []byte("h") // headerPrefix + num (uint64 big endian) + hash -> header
+
+// encodeBlockNumber encodes a block number as big endian uint64
+func encodeBlockNumber(number uint64) []byte {
+	enc := make([]byte, 8)
+	binary.BigEndian.PutUint64(enc, number)
+	return enc
+}
+
+// headerKey = headerPrefix + num (uint64 big endian) + hash
+func headerKey(number uint64, hash gethcommon.Hash) []byte {
+	return append(append(headerPrefix, encodeBlockNumber(number)...), hash.Bytes()...)
+}
+
+func TestDecodeHeaderNumberAndHash(t *testing.T) {
+	tests := []struct {
+		key            []byte
+		expectedNumber uint64
+		expectedHash   gethcommon.Hash
+		expectedOk     bool
+	}{
+		{headerKey(0, gethcommon.Hash{}), 0, gethcommon.Hash{}, true},
+		{headerKey(1, gethcommon.HexToHash("0x1")), 1, gethcommon.HexToHash("0x1"), true},
+		{headerKey(123456789, gethcommon.HexToHash("0xb44fb4e949d0f78f87f79ee46428f23a2a5713ce6fc6e0beb3dda78c2ac1ea55")), 123456789, gethcommon.HexToHash("0xb44fb4e949d0f78f87f79ee46428f23a2a5713ce6fc6e0beb3dda78c2ac1ea55"), true},
+		{headerKey(1234, gethcommon.HexToHash("0xb44fb4e949d0f78f87f79ee46428f23a2a5713ce6fc6e0beb3dda78c2ac1ea55")), 1234, gethcommon.HexToHash("0xb44fb4e949d0f78f87f79ee46428f23a2a5713ce6fc6e0beb3dda78c2ac1ea55"), true},
+		{headerKey(0, gethcommon.HexToHash("0xb44fb4e949d0f78f87f79ee46428f23a2a5713ce6fc6e0beb3dda78c2ac1ea55")), 0, gethcommon.HexToHash("0xb44fb4e949d0f78f87f79ee46428f23a2a5713ce6fc6e0beb3dda78c2ac1ea55"), true},
+		{headerKey(1234, gethcommon.Hash{}), 1234, gethcommon.Hash{}, true},
+		{append(headerKey(0, gethcommon.HexToHash("0x1")), byte('n')), 0, gethcommon.Hash{}, false},
+		{[]byte{'h', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 0, gethcommon.Hash{}, true},
+		{[]byte{'H', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 0, gethcommon.Hash{}, false},
+	}
+
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("%v:key=%v", i, string(test.key)), func(t *testing.T) {
+			num, hash, ok := decodeHeaderNumberAndHash(test.key)
+			if !test.expectedOk {
+				require.False(t, ok, "decodeHeaderNumberAndHash(%v) returned ok=true, want ok=false", test.key)
+			} else {
+				require.True(t, ok, "decodeHeaderNumberAndHash(%v) returned ok=false, want ok=true", test.key)
+				assert.Equal(t, test.expectedNumber, num)
+				assert.Equal(t, test.expectedHash, hash)
+			}
+		})
+	}
+}
+
+func TestDatabase(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockCli := rpcmock.NewMockClient(ctrl)
+	db := Hack(rawdb.NewMemoryDatabase(), mockCli)
+
+	t.Run("Get Header", func(t *testing.T) {
+		header := &gethtypes.Header{
+			Number:     big.NewInt(1234),
+			ParentHash: gethcommon.HexToHash("0xb44fb4e949d0f78f87f79ee46428f23a2a5713ce6fc6e0beb3dda78c2ac1ea55"),
+		}
+
+		mockCli.EXPECT().HeaderByHash(gomock.Any(), header.Hash()).Return(header, nil)
+		b, err := db.Get(headerKey(1234, header.Hash()))
+		require.NoError(t, err)
+		expectedB, _ := rlp.EncodeToBytes(header)
+		assert.Equal(t, hexutil.Encode(expectedB), hexutil.Encode(b))
+	})
+
+	t.Run("Get Non-Header", func(t *testing.T) {
+		b, err := db.Get([]byte("key"))
+		require.Error(t, err)
+		assert.Nil(t, b)
+	})
+}


### PR DESCRIPTION
## 📝 Description

<!-- Provide a detailed description of your changes and the motivation behind them. -->

In current Preflight implementation, ancestors headers are pre-fetched before EVM execution which requires to pessimistically fetch all 256 ancestors while they are for the vast majority of cases unnecessary (indeed transactions rarely call op-code `BLOCKHASH` for historical blocks).

This change moves ancestors fetching at EVM execution time thus avoiding fetching unnecessary ancestors. 

It hacks the underlying geth `ethdb.Database`, by intercepting calls to `Get(key []byte)` and checking whether the key is an header key in which case it fetches the header from a remote RPC. 

The `ethdb.Database` was the only geth Go interface that we could intercept in order to achieve this. This is because geth `core.HeaderChain` reads headers directly from the `ethdb.Database`.

## ✅ Solved Issues

Resolves KKRT-42 <!-- Provide references to the relevant issues, if applicable -->

## 🔄 Change

<!-- Tick the type of change introduced by this Pull Request: -->

- [x] ✨ New feature (e.g. API route, major perf improvement...)
- [ ] 🐛 Bug fix
- [ ] 🧹 Chore (e.g. package upgrades, configuration change, refactor, small perf improvement, typos...)
- [ ] 🧪 Tests
- [ ] 🏭 DevOps (e.g. CI-CD, development environment upgrade, security upgrade, automation addition...)
- [ ] 📚 Documentation

<!-- Tick if this Pull Request introduce a breaking change -->

- [ ] 💥 Breaking Change

## 💥 Breaking Change (if applicable)

<!-- If this PR introduce breaking changes, describe them here, covering the migration path (e.g., API changes, configuration updates). -->

## 📋 Checklist

<!-- Confirm the following items are completed before submitting your pull request: -->

- [x] I have added tests to cover my changes, if applicable.
- [x] I have updated relevant documentation for my changes.
- [x] I have included references to issues resolved by this Pull Request
- [x] I have set a Pull Request title that respects [gitmoji](https://gitmoji.dev/)
- [x] I have set a Pull Request's label to one of `type.feat`,`type.fix`,`type.chore`,`type.test`,`type.docs`,`type.devops`
- [x] I have set a Pull Request's label to one of `breaking-change` or `non-breaking-change`
- [ ] I have documented breaking changes and migration path, if applicable

## 📓 Additional Notes

<!-- Include any additional context, considerations, or dependencies relevant to this pull request. -->
