### PR TITLE
🐛 Fix CLI for default storage

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -145,7 +145,7 @@ func preRun(ctx *ProverInputContext, blockNumber *string) func(cmd *cobra.Comman
 
 // Helper function to validate S3 configuration
 func validateS3Config(ctx *ProverInputContext) error {
-	if ctx.Config.ProverInputStore.S3.Bucket == "" || ctx.Config.ProverInputStore.S3.BucketKeyPrefix == "" || ctx.Config.ProverInputStore.S3.AWSProvider.Credentials.AccessKey == "" || ctx.Config.ProverInputStore.S3.AWSProvider.Credentials.SecretKey == "" || ctx.Config.ProverInputStore.S3.AWSProvider.Region == "" {
+	if ctx.Config.ProverInputStore.S3.Bucket != "" || ctx.Config.ProverInputStore.S3.BucketKeyPrefix != "" || ctx.Config.ProverInputStore.S3.AWSProvider.Credentials.AccessKey != "" || ctx.Config.ProverInputStore.S3.AWSProvider.Credentials.SecretKey != "" || ctx.Config.ProverInputStore.S3.AWSProvider.Region != "" {
 		missingFields := []string{}
 		if ctx.Config.ProverInputStore.S3.Bucket == "" {
 			missingFields = append(missingFields, "s3-bucket")


### PR DESCRIPTION
## 📝 Description
On running `zkpig generate`, it asks for AWS S3 credentials to store prover inputs in S3. Instead we should by default store the prover inputs in the local directory

### Command Run
`zkpig generate`

### Current Behaviour
![image](https://github.com/user-attachments/assets/8d9156b7-452f-4e40-b04c-88a3d3f00597)

### Expected Behaviour
It should generate the prover inputs and store in the local directory

<!-- Provide a detailed description of your changes and the motivation behind them. -->

## ✅ Solved Issues

Resolves KKRT-118 <!-- Provide references to the relevant issues, if applicable -->

## 🔄 Change

<!-- Tick the type of change introduced by this Pull Request: -->

- [ ] ✨ New feature (e.g. API route, major perf improvement...)
- [x] 🐛 Bug fix
- [ ] 🧹 Chore (e.g. package upgrades, configuration change, refactor, small perf improvement, typos...)
- [ ] 🧪 Tests
- [ ] 🏭 DevOps (e.g. CI-CD, development environment upgrade, security upgrade, automation addition...)
- [ ] 📚 Documentation

<!-- Tick if this Pull Request introduce a breaking change -->

- [ ] 💥 Breaking Change

## 💥 Breaking Change (if applicable)

<!-- If this PR introduce breaking changes, describe them here, covering the migration path (e.g., API changes, configuration updates). -->

## 📋 Checklist

<!-- Confirm the following items are completed before submitting your pull request: -->

- [ ] I have added tests to cover my changes, if applicable.
- [ ] I have updated relevant documentation for my changes.
- [x] I have included references to issues resolved by this Pull Request
- [x] I have set a Pull Request title that respects [gitmoji](https://gitmoji.dev/)
- [x] I have set a Pull Request's label to one of `type.feat`,`type.fix`,`type.chore`,`type.test`,`type.docs`,`type.devops`
- [x] I have set a Pull Request's label to one of `breaking-change` or `non-breaking-change`
- [ ] I have documented breaking changes and migration path, if applicable

## 📓 Additional Notes

<!-- Include any additional context, considerations, or dependencies relevant to this pull request. -->
