### PR TITLE
📝 Fix typos and improve clarity in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,7 @@ This ensures consistency and enables automated tooling.
 
 ### Submit a Pull Request
 
-1. [Open a Pull Request](https://github.com/kkrt-labs/zk-pig/compare) from your branch targetting the `main` branch.
+1. [Open a Pull Request](https://github.com/kkrt-labs/zk-pig/compare) from your branch targeting the `main` branch.
   - Provide a clear title respecting [gitmoji](https://github.com/carloscuesta/gitmoji) message convention
   - Provide a detailed description of the change
   - Reference associated issues resolved by the Pull Request.

--- a/README.md
+++ b/README.md
@@ -1,18 +1,16 @@
 # ZK-PIG
 
-![Test](https://github.com/kkrt-labs/zk-pig/actions/workflows/test.yml/badge.svg?branch=main)
-[![codecov](https://codecov.io/gh/kkrt-labs/zk-pig/graph/badge.svg?token=ML8SpNgYm1)](https://codecov.io/gh/kkrt-labs/zk-pig)
-[![API Reference](
-https://pkg.go.dev/badge/github.com/kkrt-labs/zk-pig
-)](https://pkg.go.dev/github.com/kkrt-labs/zk-pig?tab=doc)
-[![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/kkrt-labs/zk-pig/blob/master/LICENSE.md)
+![Test](https://github.com/kkrt-labs/zk-pig/actions/workflows/test.yml/badge.svg?branch=main)  
+[![codecov](https://codecov.io/gh/kkrt-labs/zk-pig/graph/badge.svg?token=ML8SpNgYm1)](https://codecov.io/gh/kkrt-labs/zk-pig)  
+[![API Reference](https://pkg.go.dev/badge/github.com/kkrt-labs/zk-pig)](https://pkg.go.dev/github.com/kkrt-labs/zk-pig?tab=doc)  
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/kkrt-labs/zk-pig/blob/master/LICENSE.md)  
 [![Twitter](https://img.shields.io/twitter/follow/KakarotZkEvm.svg)](https://x.com/intent/follow?screen_name=KakarotZkEvm)
 
-**ZK-PIG** is a ZK-EVM Prover Input generator responsible for generating the data inputs necessary for proving Execution Layer (EL) blocks. Those prover inputs can later be consumed by proving infrastructures to generate EL block proofs.
+**ZK-PIG** is a ZK-EVM Prover Input generator responsible for generating the data inputs necessary for proving Execution Layer (EL) blocks. These prover inputs can later be consumed by proving infrastructures to generate EL block proofs.
 
-From an architecture perspective, ZK-PIG connects to an Ethereum compatible EL full or archive node via JSON-RPC to fetch the necessary data.
+From an architecture perspective, ZK-PIG connects to an Ethereum-compatible EL full or archive node via JSON-RPC to fetch the necessary data.
 
-> **Note about Prover Inputs:** ZK-EVM proving engines operate in isolated & stateless environments without a direct access to a full blockchain node. The **Prover Input** refer to the minimal EVM data required by such a ZK-EVM proving engine to effectively prove an EL block. For more information on prover inputs, you can refer to this [article](https://ethresear.ch/t/zk-evm-prover-input-standardization/21626).
+> **Note about Prover Inputs:** ZK-EVM proving engines operate in isolated & stateless environments without direct access to a full blockchain node. The **Prover Input** refers to the minimal EVM data required by such a ZK-EVM proving engine to effectively prove an EL block. For more information on prover inputs, you can refer to this [article](https://ethresear.ch/t/zk-evm-prover-input-standardization/21626).
 
 The **Kakarot Controller** is a monorepo housing all the services necessary for managing and orchestrating Kakarot proving operations.
 
@@ -22,19 +20,19 @@ The **Kakarot Controller** is a monorepo housing all the services necessary for 
 
 `zkpig` is distributed with Homebrew.
 
-If installing for the first time you'll need to add the `kkrt-labs/kkrt` tap
+If installing for the first time, you'll need to add the `kkrt-labs/kkrt` tap:
 
 ```sh
 brew tap kkrt-labs/kkrt
 ```
 
-Then to install `zkpig`, run 
+Then to install `zkpig`, run:
 
 ```sh
 brew install zkpig
 ```
 
-You can test the installation by running
+To test the installation, run:
 
 ```sh
 zkpig version
@@ -42,31 +40,31 @@ zkpig version
 
 ## Architecture
 
-For a more detailed architecture documentation, you can refer to the [Documentation](https://kkrt-labs/zkpig/docs/prover-input-generation.md).
+For more detailed architecture documentation, you can refer to the [Documentation](https://github.com/kkrt-labs/zk-pig/blob/main/docs/prover-input-generation.md).
 
 ## Contributing
 
-Interested in contributing? Check out our [Contributing Guidelines](CONTRIBUTING.md) to get started! 
+Interested in contributing? Check out our [Contributing Guidelines](CONTRIBUTING.md) to get started!
 
 ## Usage
 
 ### Prerequisites
 
-- You have an Ethereum Execution Layer compatible node accessible via JSON-RPC (e.g., Geth, Erigon, Infura, etc.).
+- You have an Ethereum Execution Layer-compatible node accessible via JSON-RPC (e.g., Geth, Erigon, Infura, etc.).
 
-    > **⚠️ Warning ⚠️:** If generating prover inputs for an old block, you must use an Ethereum archive node, that effectively exposes `eth_getProof` JSON-RPC for the block in question. Otherwise, ZK-PIG will fail at generating the prover inputs due to missing data.
+    > **⚠️ Warning ⚠️:** If generating prover inputs for an old block, you must use an Ethereum archive node that effectively exposes `eth_getProof` JSON-RPC for the block in question. Otherwise, ZK-PIG will fail at generating the prover inputs due to missing data.
 
     > **Note:** ZK-PIG is compatible with both HTTP and WebSocket JSON-RPC endpoints.
 
 ### Generate Prover Inputs
 
-First, you can set the `CHAIN_RPC_URL` environment variable to the URL of the Ethereum node to collect the data from.
+First, set the `CHAIN_RPC_URL` environment variable to the URL of the Ethereum node from which to collect data:
 
 ```sh
 export CHAIN_RPC_URL=<rpc-url>
 ```
 
-To generate prover inputs for a given block, you can use the following command:
+To generate prover inputs for a given block, use the following command:
 
 ```sh
 zkpig generate --block-number <block-number>
@@ -76,7 +74,7 @@ zkpig generate --block-number <block-number>
 
 On successful completion, the prover inputs are stored in the `/data` directory.
 
-To generate prover inputs for the `latest` block, you can use the following command:
+To generate prover inputs for the `latest` block, use the following command:
 
 ```sh
 zkpig generate
@@ -90,7 +88,7 @@ zkpig generate --help
 
 ### Logging
 
-To configure logging you can set
+To configure logging, you can set:
 - `--log-level` to configure verbosity (`debug`, `info`, `warn`, `error`)
 - `--log-format` to switch between `json` and `text`. For example:
 
@@ -101,10 +99,9 @@ zkpig generate \
   --log-format text
 ```
 
-
 ## Commands Overview
 
-To get the list of all available commands, and flags, you can run:
+To get the list of all available commands and flags, you can run:
 
 ```sh
 zkpig help
@@ -112,7 +109,7 @@ zkpig help
 
 ### `zkpig generate`
 
-> Description: Generates prover inputs for a given block. It consist in running preflight, prepare and execute in a single run.
+> Description: Generates prover inputs for a given block. It consists of running preflight, prepare, and execute in a single run.
 
 #### Usage
 
@@ -120,13 +117,13 @@ zkpig help
 zkpig generate \
   --block-number 1234 \
   --chain-rpc-url http://127.0.0.1:8545 \
-  --data-dir ./data
+  --data-dir ./data \
   --inputs-content-type json
 ```
 
 ### `zkpig preflight`
 
-> Description: Only fetches and locally stores the the necessary data (e.g. pre-state, block, transactions, state proofs, etc.) but does not run block validation. This is useful if you want to collect the data for a block and run block validation separately. It is also useful for debugging purposes.
+> Description: Only fetches and locally stores the necessary data (e.g., pre-state, block, transactions, state proofs, etc.) but does not run block validation. This is useful if you want to collect the data for a block and run block validation separately. It is also useful for debugging purposes.
 
 #### Usage
 
@@ -134,14 +131,14 @@ zkpig generate \
 zkpig preflight \
   --block-number 1234 \
   --chain-rpc-url http://127.0.0.1:8545 \
-  --data-dir ./data
+  --data-dir ./data \
   --inputs-content-type json
 ```
 
 ### `zkpig prepare`
 
-> Description: Converts the data collected during preflight data into the minimal, final prover input.
-> Can be ran offline without a chain-rpc-url. In which case it needs to be provided with a chain-id.
+> Description: Converts the data collected during preflight into the minimal, final prover input.  
+> Can be run offline without a chain-rpc-url. In that case, it needs to be provided with a chain-id.
 
 #### Usage
 
@@ -156,8 +153,8 @@ zkpig prepare \
 
 ### `zkpig execute`
 
-> Description: Re-executes the block over the previously generated prover inputs.
-> Can be ran offline without a chain-rpc-url. In which case it needs to be provided with a chain-id.
+> Description: Re-executes the block over the previously generated prover inputs.  
+> Can be run offline without a chain-rpc-url. In that case, it needs to be provided with a chain-id.
 
 #### Usage
 

--- a/docs/about-ethereum.md
+++ b/docs/about-ethereum.md
@@ -51,7 +51,7 @@ This includes
    - when accessing a state data (either an account or a storage slot)
    - when deleting some state entries which may result in a [MPT branch node reduction](modified-mpt.md#branch-node-reduction) which resolves extra nodes
 - **codes** of all smart contracts called during block execution
-- **ancestors headers**, minimally containing the direct parent of the executed block and optionnaly older ancestors if accessed with opcode `BLOCKHASH` during block execution. For instance, the opcode `BLOCKHASH`enables smart contracts to access the hash of any of the 256 most recent blocks (excluding the current block, as its hash is computed post-execution)
+- **ancestors headers**, minimally containing the direct parent of the executed block and optionally older ancestors if accessed with opcode `BLOCKHASH` during block execution. For instance, the opcode `BLOCKHASH`enables smart contracts to access the hash of any of the 256 most recent blocks (excluding the current block, as its hash is computed post-execution)
 
 ### Witness examples
 

--- a/docs/prover-input-generation.md
+++ b/docs/prover-input-generation.md
@@ -2,7 +2,7 @@
 
 This page describes the process for generating Prover Input the minimal necessary data for ZK EVM prover engines to prove a block. 
 
-It consists of 3 steps: [1. Prefligth](#step-1-preflight), [2. Prepare](#step-2-prepare) and [3. Execute](#step-3-execute)
+It consists of 3 steps: [1. Preflight](#step-1-preflight), [2. Prepare](#step-2-prepare) and [3. Execute](#step-3-execute)
 
 ## About Ethereum
 
@@ -76,7 +76,7 @@ The intermediary `PreflightData` contains:
 - **Pre-State Proofs**: The list of pre-state proofs for every accounts and storage accessed during block execution, obtained via `eth_getProof(account, accessedSlots, parent.Number)` after preflight block execution
 - **Post-State Proofs**: The list of post-state proofs for every destructed accounts and deleted storage during block execution, obtained via `eth_getProof(..., block.Number)` after preflight block execution
 
-The `PreflightData` contain redundant and unnecessary data which is later optimized during [Prepare](#step-2-prepare).
+The `PreflightData` contain redundant data which is later optimized during [Prepare](#step-2-prepare).
 
 #### Step 2: Prepare
 


### PR DESCRIPTION
- Corrected missing word "the" in descriptions
- Fixed broken link to architecture documentation
- Improved punctuation and readability in command usage examples
- Updated warnings and notes for better clarity
- Corrected the spelling of "optionnaly" to "optionally"
- Fixed the spelling of "Prefligth" to "Preflight" in all instances

