### PR TITLE
🐛 Fix incorrect format specifier in validateS3Config error message

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -200,7 +200,7 @@ func validateS3Config(ctx *ProverInputContext) error {
 
 		// If any required field is missing, return an error
 		if len(missingFields) > 0 {
-			return fmt.Errorf("%s must be specified when using s3 storage", missingFields)
+			return fmt.Errorf("%v must be specified when using s3 storage", missingFields)
 		}
 	}
 


### PR DESCRIPTION

✅ Description
This PR fixes a formatting issue in the validateS3Config function in cmd/generate.go. The error message previously used %s, which is incorrect for slices. It has been replaced with %v to properly format the missingFields slice.

🔄 Changes

Fixed format specifier in error message
Before:
return fmt.Errorf("%s must be specified when using s3 storage", missingFields)

After:
return fmt.Errorf("%v must be specified when using s3 storage", missingFields)
📂 File Changed

cmd/generate.go
🛠 Reason for Change
Using %s for a slice (missingFields) leads to incorrect formatting and potential runtime issues. %v correctly formats slices, ensuring all missing fields are displayed in the error message.

🔍 Type of Change

🐛 Bug fix (formatting issue correction)
🏭 DevOps (error handling improvement)
🚀 Impact
No breaking changes, just improved error message correctness.