### PR TITLE
Grammar and Spelling Fixes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,5 @@
 # This file is used by the release workflow to generate a draft release on GitHub.
-# It bases on Pull Requests and their labels to generate the changelog.
+# It is bases on Pull Requests and their labels to generate the changelog.
 category-template: '### $TITLE'
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/kkrt-labs/zk-pig/blob/master/LICENSE)  
 [![Twitter](https://img.shields.io/twitter/follow/KakarotZkEvm.svg)](https://x.com/intent/follow?screen_name=KakarotZkEvm)
 
-**ZK-PIG** is a ZK-EVM Prover Input generator responsible for generating the data inputs necessary for proving Execution Layer (EL) blocks. These prover inputs can later be consumed by proving infrastructures to generate EL block proofs.
+**ZK-PIG** is a ZK-EVM Prover Input generator responsible for generating the data inputs necessary for proving Execution Layer (EL) blocks. These prover inputs can later be consumed by proving infrastructure to generate EL block proofs.
 
 From an architecture perspective, ZK-PIG connects to an Ethereum-compatible EL full or archive node via JSON-RPC to fetch the necessary data.
 

--- a/docs/modified-mpt.md
+++ b/docs/modified-mpt.md
@@ -107,7 +107,7 @@ This modified MPT is used during both [Prepare](prover-input-generation.md#step-
 
 To further address this issue, we use a supplemental technique during the [Prepare](prover-input-generation.md#step-2-prepare) phase. 
 
-For every deletion resulting in a branch node reduction, we pre-inject some hypothetized short-nodes into the pre-state, ensuring that if the remaining child is a short-node, then it resolves to one of the pre-injected hypothetized short nodes. Consequently, ensuring that, during branch node reduction, the remaining child node resolution will succeed.
+For every deletion resulting in a branch node reduction, we pre-inject some hypothesized short-nodes into the pre-state, ensuring that if the remaining child is a short-node, then it resolves to one of the pre-injected hypothetized short nodes. Consequently, ensuring that, during branch node reduction, the remaining child node resolution will succeed.
 
 To compute the hypothetized short-nodes, we base on the post-state proof for every deleted MPT path. Indeed, in case of a deletion, the post-state proof is actually an exclusion proof, in which the last proof's element is an MPT node proving that there is no value at the given path. If this last proof's item is a short-node, this means that the deletion triggered a branch node reduction, and it is possible to compute all the short-nodes that could have potentially reduced into the last proof's element (see [below](#pre-state-preparation-workflow)).
 


### PR DESCRIPTION
Original: "It bases on Pull Requests and their labels to generate the changelog."
Updated: "It is based on Pull Requests and their labels to generate the changelog."
Reason: "Bases on" is incorrect; the correct phrase is "is based on."

Original: "These prover inputs can later be consumed by proving infrastructures to generate EL block proofs."
Updated: "These prover inputs can later be consumed by proving infrastructure to generate EL block proofs."
Reason: "Infrastructures" should be singular ("infrastructure") since it is an uncountable noun in this context.

Original: "hypothetized"
Updated: "hypothesized"
Reason: "Hypothetized" is incorrect; the correct spelling is "hypothesized."
