### PR TITLE
docs: fix typo in "stateless EVM block execution" section `non-breaking-change` `type.docs`

### DIFF
--- a/docs/about-ethereum.md
+++ b/docs/about-ethereum.md
@@ -42,7 +42,7 @@ Practically, the final state root `S'` is first computed by the block proposer a
 
 ## Block witness
 
-Block witness encompasses the minimal state and chain data required for a stateless EVM block execution (meaning without access to a a database containing the full state) which includes
+Block witness encompasses the minimal state and chain data required for a stateless EVM block execution (meaning without access to a database containing the full state) which includes
 - performing all block operations (apply transactions, apply fee rewards, apply system calls, etc.) 
 - deriving the post state root
 


### PR DESCRIPTION
## 📝 Description

<img width="937" alt="Снимок экрана 2025-03-16 в 13 56 19" src="https://github.com/user-attachments/assets/6256105d-3c38-4431-abfc-35ab04c3142e" />

Fixed a typo in the documentation where the article "a" was repeated in the "stateless EVM block execution" section.
It has been corrected to make the sentence grammatically accurate and clearer.

## ✅ Solved Issues

- Fixed typo in the documentation.

## 🔄 Change

- [ ] ✨ New feature (e.g. API route, major perf improvement...)
- [ ] 🐛 Bug fix
- [ ] 🧹 Chore (e.g. package upgrades, configuration change, refactor, small perf improvement, typos...)
- [ ] 🧪 Tests
- [ ] 🏭 DevOps (e.g. CI-CD, development environment upgrade, security upgrade, automation addition...)
- [x] 📚 Documentation

- [ ] 💥 Breaking Change

## 💥 Breaking Change (if applicable)

N/A

## 📋 Checklist

- [ ] I have added tests to cover my changes, if applicable.
- [ ] I have updated relevant documentation for my changes.
- [ ] I have included references to issues resolved by this Pull Request
- [ ] I have set a Pull Request title that respects [[gitmoji](https://gitmoji.dev/)](https://gitmoji.dev/)
- [x] I have set a Pull Request's label to one of `type.feat`,`type.fix`,`type.chore`,`type.test`,`type.docs`,`type.devops`
- [x] I have set a Pull Request's label to one of `breaking-change` or `non-breaking-change`
- [ ] I have documented breaking changes and migration path, if applicable

## 📓 Additional Notes

N/A

--- 

Let me know if you'd like to change anything!