### PR TITLE
✨ Add Block Filtering Capability to Generator Daemon

### DIFF
--- a/src/app.go
+++ b/src/app.go
@@ -645,9 +645,13 @@ func (a *App) Daemon() *generator.Daemon {
 		fmt.Sprintf("%s.daemon", generatorComponentName),
 		func() (*generator.Daemon, error) {
 			a.app.EnableHealthzEntrypoint()
-			return &generator.Daemon{
-				Generator: a.Generator(),
-			}, nil
+
+			filter := generator.FilterByBlockNumberModulo(uint64(a.Config().Generator.Filter.Modulo.Value))
+
+			return generator.NewDaemon(
+				a.Generator(),
+				generator.WithFilter(filter),
+			), nil
 		},
 		app.WithComponentName(generatorComponentName), // override component name
 	)

--- a/src/config.go
+++ b/src/config.go
@@ -19,6 +19,11 @@ type Config struct {
 	Config    []string `mapstructure:"config"`
 	Generator struct {
 		Include []string `mapstructure:"include"`
+		Filter  struct {
+			Modulo struct {
+				Value int `mapstructure:"value"`
+			} `mapstructure:"modulo,omitempty"`
+		} `mapstructure:"filter,omitempty"`
 	} `mapstructure:"generator"`
 	PreflightDataStore struct {
 		File struct {

--- a/src/flags.go
+++ b/src/flags.go
@@ -31,10 +31,18 @@ var (
 		Env:         "INCLUDE",
 		Description: fmt.Sprintf("Data to include in the generated Prover Input (valid options: %q)", steps.ValidIncludes),
 	}
+	generatorFilterModuloFlag = &spf13.IntFlag{
+		ViperKey:     "generator.filter.modulo.value",
+		Name:         "filter-modulo",
+		Env:          "FILTER_MODULO",
+		Description:  "Does not generate prover input for blocks which number is not divisible by the given modulo",
+		DefaultValue: common.Ptr(5),
+	}
 )
 
 func AddGeneratorFlags(v *viper.Viper, f *pflag.FlagSet) {
 	generatorInclusionsFlag.Add(v, f)
+	generatorFilterModuloFlag.Add(v, f)
 }
 
 var (

--- a/src/generator/deamon_test.go
+++ b/src/generator/deamon_test.go
@@ -1,10 +1,20 @@
 package generator
 
 import (
+	"context"
+	"math/big"
 	"testing"
+	"time"
 
+	gethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/kkrt-labs/go-utils/app/svc"
+	mockethrpc "github.com/kkrt-labs/go-utils/ethereum/rpc/mock"
+	input "github.com/kkrt-labs/zk-pig/src/prover-input"
+	"github.com/kkrt-labs/zk-pig/src/steps"
+	mocksteps "github.com/kkrt-labs/zk-pig/src/steps/mock"
+	mockstore "github.com/kkrt-labs/zk-pig/src/store/mock"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 )
 
 func TestDaemonImplementsService(t *testing.T) {
@@ -12,4 +22,63 @@ func TestDaemonImplementsService(t *testing.T) {
 	require.Implements(t, (*svc.Metricable)(nil), new(Daemon))
 	require.Implements(t, (*svc.MetricsCollector)(nil), new(Daemon))
 	require.Implements(t, (*svc.Runnable)(nil), new(Daemon))
+}
+
+func TestDaemon(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ethrpc := mockethrpc.NewMockClient(ctrl)
+
+	preflighter := mocksteps.NewMockPreflight(ctrl)
+	preparer := mocksteps.NewMockPreparer(ctrl)
+	executor := mocksteps.NewMockExecutor(ctrl)
+
+	proverInputStore := mockstore.NewMockProverInputStore(ctrl)
+	preflightDataStore := mockstore.NewMockPreflightDataStore(ctrl)
+
+	generator, err := NewGenerator(&Config{
+		RPC:                ethrpc,
+		Preflighter:        preflighter,
+		Preparer:           preparer,
+		Executor:           executor,
+		ProverInputStore:   proverInputStore,
+		PreflightDataStore: preflightDataStore,
+	})
+	require.NoError(t, err)
+	generator.SetMetrics("test", "test")
+
+	daemon := NewDaemon(
+		generator,
+		WithFilter(NoFilter()),
+		WithFetchInterval(100*time.Second), // set a long interval so we can control the flow of the test
+	)
+	daemon.SetMetrics("test", "test")
+
+	testBlock := gethtypes.NewBlockWithHeader(&gethtypes.Header{Number: big.NewInt(1)})
+	testData := new(steps.PreflightData)
+	testInput := &input.ProverInput{
+		Blocks: []*input.Block{
+			{
+				Header:       testBlock.Header(),
+				Transactions: testBlock.Transactions(),
+				Uncles:       testBlock.Uncles(),
+				Withdrawals:  testBlock.Withdrawals(),
+			},
+		},
+	}
+	rpcCall := ethrpc.EXPECT().BlockByNumber(gomock.Any(), nil).Return(testBlock, nil)
+	preflightCall := preflighter.EXPECT().Preflight(gomock.Any(), gomock.Any()).Return(testData, nil).After(rpcCall)
+	preflightDataStore.EXPECT().StorePreflightData(gomock.Any(), gomock.Any()).After(preflightCall)
+	prepareCall := preparer.EXPECT().Prepare(gomock.Any(), gomock.Any()).Return(testInput, nil).After(preflightCall)
+	executeCall := executor.EXPECT().Execute(gomock.Any(), gomock.Any()).Return(nil, nil).After(prepareCall)
+	proverInputStore.EXPECT().StoreProverInput(gomock.Any(), gomock.Any()).After(executeCall)
+
+	err = daemon.Start(context.TODO())
+	require.NoError(t, err)
+
+	time.Sleep(100 * time.Millisecond) // wait for the daemon to start
+
+	err = daemon.Stop(context.TODO())
+	require.NoError(t, err)
 }

--- a/src/generator/filters.go
+++ b/src/generator/filters.go
@@ -1,0 +1,37 @@
+package generator
+
+import gethtypes "github.com/ethereum/go-ethereum/core/types"
+
+// BlockFilter is an interface that defines a filter for blocks
+type BlockFilter interface {
+	// Filter returns true if the block should be processed
+	Filter(block *gethtypes.Block) bool
+}
+
+// BlockFilterFunc is a function that implements the BlockFilter interface
+type BlockFilterFunc func(block *gethtypes.Block) bool
+
+// Filter is a method that implements the BlockFilter interface
+func (f BlockFilterFunc) Filter(block *gethtypes.Block) bool {
+	return f(block)
+}
+
+// NoFilter is a filter that always returns true
+func NoFilter() BlockFilter {
+	return BlockFilterFunc(func(_ *gethtypes.Block) bool {
+		return true
+	})
+}
+
+// FilterByBlockNumberModulo is a filter that returns true if the block number is not divisible by the modulo
+func FilterByBlockNumberModulo(modulo uint64) BlockFilter {
+	return BlockFilterFunc(func(block *gethtypes.Block) bool {
+		return block.NumberU64()%modulo == 0
+	})
+}
+
+func WithFilter(filter BlockFilter) DaemonOption {
+	return func(d *Daemon) {
+		d.filter = filter
+	}
+}

--- a/src/generator/filters_test.go
+++ b/src/generator/filters_test.go
@@ -1,0 +1,20 @@
+package generator
+
+import (
+	"math/big"
+	"testing"
+
+	gethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNoFilter(t *testing.T) {
+	filter := NoFilter()
+	assert.True(t, filter.Filter(&gethtypes.Block{}))
+}
+
+func TestFilterByBlockNumberModulo(t *testing.T) {
+	filter := FilterByBlockNumberModulo(10)
+	assert.True(t, filter.Filter(gethtypes.NewBlockWithHeader(&gethtypes.Header{Number: big.NewInt(10)})))
+	assert.False(t, filter.Filter(gethtypes.NewBlockWithHeader(&gethtypes.Header{Number: big.NewInt(11)})))
+}


### PR DESCRIPTION
## 📝 Description

<!-- Provide a detailed description of your changes and the motivation behind them. -->

This PR introduces a block filtering mechanism to the Generator Daemon, allowing selective processing of blocks based on configurable criteria. Initially, it implements a modulo-based filter that processes only blocks whose numbers are divisible by a configured value.

## Changes

- Added a new `BlockFilter` interface and implementation for filtering blocks
- Introduced configuration options for block filtering via flags and config file
- Modified the Daemon initialization to support filters
- Added unit tests for filter functionality

### New Configuration

- Added `--filter-modulo` flag (env: `FILTER_MODULO`, default: 5)
- Configuration file support via:
  ```yaml
  generator:
    filter:
      modulo:
        value: 5  # Process only blocks divisible by 5
  ```

## ✅ Solved Issues

Resolves KKRT-133 <!-- Provide references to the relevant issues, if applicable -->

## 🔄 Change

<!-- Tick the type of change introduced by this Pull Request: -->

- [x] ✨ New feature (e.g. API route, major perf improvement...)
- [ ] 🐛 Bug fix
- [ ] 🧹 Chore (e.g. package upgrades, configuration change, refactor, small perf improvement, typos...)
- [ ] 🧪 Tests
- [ ] 🏭 DevOps (e.g. CI-CD, development environment upgrade, security upgrade, automation addition...)
- [ ] 📚 Documentation

<!-- Tick if this Pull Request introduce a breaking change -->

- [ ] 💥 Breaking Change

## 💥 Breaking Change (if applicable)

<!-- If this PR introduce breaking changes, describe them here, covering the migration path (e.g., API changes, configuration updates). -->

## 📋 Checklist

<!-- Confirm the following items are completed before submitting your pull request: -->

- [ ] I have added tests to cover my changes, if applicable.
- [ ] I have updated relevant documentation for my changes.
- [ ] I have included references to issues resolved by this Pull Request
- [ ] I have set a Pull Request title that respects [gitmoji](https://gitmoji.dev/)
- [ ] I have set a Pull Request's label to one of `type.feat`,`type.fix`,`type.chore`,`type.test`,`type.docs`,`type.devops`
- [ ] I have set a Pull Request's label to one of `breaking-change` or `non-breaking-change`
- [ ] I have documented breaking changes and migration path, if applicable

## 📓 Additional Notes

<!-- Include any additional context, considerations, or dependencies relevant to this pull request. -->
