### PR TITLE
Remove unsupported formatters from golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,6 @@
 linters:
   enable:
     - goconst
-    - goimports
     - gocritic
     - revive
     - misspell
@@ -10,7 +9,6 @@ linters:
     - unconvert
     - unparam
     - gocheckcompilerdirectives
-    - gofmt
 
 linters-settings:
   govet:


### PR DESCRIPTION
## 📝 Description

Removed `goimports`, and `gofmt` from `.golangci.yml` because they are now considered formatters, not linters. Without these changes, golangci-lint fails with errors. Locally tested per the official migration guide.

## 🔄 Change

<!-- Tick the type of change introduced by this Pull Request: -->

- [ ] ✨ New feature (e.g. API route, major perf improvement...)
- [ ] 🐛 Bug fix
- [x] 🧹 Chore (e.g. package upgrades, configuration change, refactor, small perf improvement, typos...)
- [x] 🧪 Tests
- [ ] 🏭 DevOps (e.g. CI-CD, development environment upgrade, security upgrade, automation addition...)
- [ ] 📚 Documentation

## 📋 Checklist

<!-- Confirm the following items are completed before submitting your pull request: -->

- [x] I have added tests to cover my changes, if applicable.
- [x] I have updated relevant documentation for my changes.
- [ ] I have included references to issues resolved by this Pull Request
- [x] I have set a Pull Request title that respects [gitmoji](https://gitmoji.dev/)
- [ ] I have set a Pull Request's label to one of `type.feat`,`type.fix`,`type.chore`,`type.test`,`type.docs`,`type.devops`
- [ ] I have set a Pull Request's label to one of `breaking-change` or `non-breaking-change`
- [x] I have documented breaking changes and migration path, if applicable

