### PR TITLE
💄 Rename CLI flags to --include-extensions --filter-modulo --store-preflight-data

### DIFF
--- a/src/config.go
+++ b/src/config.go
@@ -64,6 +64,7 @@ func DefaultConfig() *Config {
 		Generator: &GeneratorConfig{
 			StorePreflightData: common.Ptr(false),
 			FilterModulo:       common.Ptr(uint64(5)),
+			IncludeExtensions:  common.Ptr(steps.IncludeAll),
 		},
 	}
 }
@@ -74,7 +75,7 @@ type Config struct {
 	Chain        *ChainConfig        `key:"chain"`
 	Store        *StoreConfig        `key:"store"`
 	ProverInputs *ProverInputsConfig `key:"inputs" env:"INPUTS" flag:"inputs"`
-	Generator    *GeneratorConfig    `key:"generator"`
+	Generator    *GeneratorConfig    `key:"generator" env:"-" flag:"-"`
 }
 
 func (cfg *Config) Load(v *viper.Viper) error {
@@ -154,6 +155,6 @@ type ProverInputsConfig struct {
 
 type GeneratorConfig struct {
 	StorePreflightData *bool          `key:"store-preflight-data" env:"STORE_PREFLIGHT_DATA" flag:"store-preflight-data" desc:"Store intermediate preflight data when generating prover inputs"`
-	IncludeExtensions  *steps.Include `key:"include" env:"INCLUDE_EXTENSIONS" desc:"Optionnal extended data to include in the generated Prover Input (e.g. accessList, preState, stateDiffs, committed, all)"`
+	IncludeExtensions  *steps.Include `key:"include" env:"INCLUDE_EXTENSIONS" flag:"include-extensions" desc:"Optionnal extended data to include in the generated prover input (e.g. \"accessList\" \"preState\" \"stateDiffs\" \"committed\" \"all\")"`
 	FilterModulo       *uint64        `key:"filter-modulo" env:"FILTER_MODULO" flag:"filter-modulo" desc:"Generate prover input for blocks which number is divisible by the given modulo"`
 }

--- a/src/config_test.go
+++ b/src/config_test.go
@@ -259,9 +259,9 @@ func TestEnv(t *testing.T) {
 		"STORE_AWS_S3_PREFIX":                      "test-prefix",
 		"STORE_CONTENT_ENCODING":                   "gzip",
 		"INPUTS_CONTENT_TYPE":                      "application/protobuf",
-		"GENERATOR_STORE_PREFLIGHT_DATA":           "true",
-		"GENERATOR_FILTER_MODULO":                  "15",
-		"GENERATOR_INCLUDE_EXTENSIONS":             "accessList,preState",
+		"STORE_PREFLIGHT_DATA":                     "true",
+		"FILTER_MODULO":                            "15",
+		"INCLUDE_EXTENSIONS":                       "accessList,preState",
 	}, env)
 }
 
@@ -275,9 +275,7 @@ func TestFlagsUsage(t *testing.T) {
 	expectedUsage := `      --chain-id string                                   Chain ID (decimal) [env: CHAIN_ID]
       --chain-rpc-url string                              Chain JSON-RPC URL [env: CHAIN_RPC_URL]
   -c, --config strings                                     [env: CONFIG] (default [config.yaml,config.yml])
-      --generator-filter-modulo uint                      Generate prover input for blocks which number is divisible by the given modulo [env: GENERATOR_FILTER_MODULO] (default 5)
-      --generator-includeextensions string                Optionnal extended data to include in the generated Prover Input (e.g. accessList [env: GENERATOR_INCLUDE_EXTENSIONS] (default "none")
-      --generator-store-preflight-data                    Store intermediate preflight data when generating prover inputs [env: GENERATOR_STORE_PREFLIGHT_DATA]
+      --filter-modulo uint                                Generate prover input for blocks which number is divisible by the given modulo [env: FILTER_MODULO] (default 5)
       --healthz-ep-addr string                            healthz entrypoint: TCP Address to listen on [env: HEALTHZ_EP_ADDR] (default ":8081")
       --healthz-ep-http-idle-timeout string               healthz entrypoint: Maximum duration to wait for the next request when keep-alives are enabled (zero uses the value of read timeout) [env: HEALTHZ_EP_HTTP_IDLE_TIMEOUT] (default "30s")
       --healthz-ep-http-max-header-bytes int              healthz entrypoint: Maximum number of bytes the server will read parsing the request header's keys and values [env: HEALTHZ_EP_HTTP_MAX_HEADER_BYTES] (default 1048576)
@@ -289,6 +287,7 @@ func TestFlagsUsage(t *testing.T) {
       --healthz-ep-net-keep-alive-probe-enable            healthz entrypoint: Enable keep alive probes [env: HEALTHZ_EP_NET_KEEP_ALIVE_PROBE_ENABLE]
       --healthz-ep-net-keep-alive-probe-idle string       healthz entrypoint: Time that the connection must be idle before the first keep-alive probe is sent [env: HEALTHZ_EP_NET_KEEP_ALIVE_PROBE_IDLE] (default "15s")
       --healthz-ep-net-keep-alive-probe-interval string   healthz entrypoint: Time between keep-alive probes [env: HEALTHZ_EP_NET_KEEP_ALIVE_PROBE_INTERVAL] (default "15s")
+      --include-extensions string                         Optionnal extended data to include in the generated prover input (e.g. "accessList" "preState" "stateDiffs" "committed" "all") [env: INCLUDE_EXTENSIONS] (default "all")
       --inputs-content-type string                        Content type (e.g. json) [env: INPUTS_CONTENT_TYPE] (default "application/json")
       --log-enable-caller                                 Enable caller [env: LOG_ENABLE_CALLER]
       --log-enable-stacktrace                             Enable automatic stacktrace capturing [env: LOG_ENABLE_STACKTRACE]
@@ -335,6 +334,7 @@ func TestFlagsUsage(t *testing.T) {
       --store-content-encoding string                     Content encoding (e.g. gzip) [env: STORE_CONTENT_ENCODING] (default "plain")
       --store-file-dir string                             Path to local data directory [env: STORE_FILE_DIR] (default "data")
       --store-file-enabled                                Enable file store [env: STORE_FILE_ENABLED] (default true)
+      --store-preflight-data                              Store intermediate preflight data when generating prover inputs [env: STORE_PREFLIGHT_DATA]
 `
 
 	expectedRaws := strings.Split(expectedUsage, "\n")


### PR DESCRIPTION
## 📝 Description

<!-- Provide a detailed description of your changes and the motivation behind them. -->

Rename following zkpig CLI flags
- `--generator-include-extensions` -> `--include-extensions`
- `--generator-filter-modulo` -> `--filter-modulo`
- `--generator-store-preflight-data`-> `--store-preflight-data`

Same renaming approach applies to environment variables:
- `GENERATOR_<var>` -> `<var>`

## ✅ Solved Issues

Resolves <!-- Provide references to the relevant issues, if applicable -->

## 🔄 Change

<!-- Tick the type of change introduced by this Pull Request: -->

- [ ] ✨ New feature (e.g. API route, major perf improvement...)
- [ ] 🐛 Bug fix
- [ ] 🧹 Chore (e.g. package upgrades, configuration change, refactor, small perf improvement, typos...)
- [ ] 🧪 Tests
- [ ] 🏭 DevOps (e.g. CI-CD, development environment upgrade, security upgrade, automation addition...)
- [ ] 📚 Documentation

<!-- Tick if this Pull Request introduce a breaking change -->

- [x] 💥 Breaking Change

## 💥 Breaking Change (if applicable)

<!-- If this PR introduce breaking changes, describe them here, covering the migration path (e.g., API changes, configuration updates). -->

Following zkpig CLI flags have been renamed
- `--generator-include-extensions` -> `--include-extensions`
- `--generator-filter-modulo` -> `--filter-modulo`
- `--generator-store-preflight-data`-> `--store-preflight-data`

Same renaming approach applies to environment variables:
- `GENERATOR_<var>` -> `<var>`

## 📋 Checklist

<!-- Confirm the following items are completed before submitting your pull request: -->

- [ ] I have added tests to cover my changes, if applicable.
- [ ] I have updated relevant documentation for my changes.
- [ ] I have included references to issues resolved by this Pull Request
- [ ] I have set a Pull Request title that respects [gitmoji](https://gitmoji.dev/)
- [ ] I have set a Pull Request's label to one of `type.feat`,`type.fix`,`type.chore`,`type.test`,`type.docs`,`type.devops`
- [ ] I have set a Pull Request's label to one of `breaking-change` or `non-breaking-change`
- [ ] I have documented breaking changes and migration path, if applicable

## 📓 Additional Notes

<!-- Include any additional context, considerations, or dependencies relevant to this pull request. -->
