### PR TITLE
💥 Update data store paths for prover input and preflight data

### DIFF
--- a/src/store/input_store.go
+++ b/src/store/input_store.go
@@ -97,7 +97,7 @@ func (s *proverInputStore) LoadProverInput(ctx context.Context, chainID, blockNu
 }
 
 func (s *proverInputStore) path(chainID, blockNumber uint64) string {
-	return s.contentType.FilePath(fmt.Sprintf("/%d/inputs/%d", chainID, blockNumber))
+	return s.contentType.FilePath(fmt.Sprintf("/%d/%d/zkpi", chainID, blockNumber))
 }
 
 type noOpProverInputStore struct{}

--- a/src/store/input_store_test.go
+++ b/src/store/input_store_test.go
@@ -36,14 +36,14 @@ func TestProverInputStore(t *testing.T) {
 			contentType: store.ContentTypeJSON,
 			chainID:     2,
 			blockNumber: 15,
-			expectedKey: "/2/inputs/15.json",
+			expectedKey: "/2/15/zkpi.json",
 		},
 		{
 			desc:        "Protobuf Plain File",
 			contentType: store.ContentTypeProtobuf,
 			chainID:     2,
 			blockNumber: 15,
-			expectedKey: "/2/inputs/15.protobuf",
+			expectedKey: "/2/15/zkpi.protobuf",
 		},
 	}
 	for _, tt := range testCases {

--- a/src/store/preflight_data_store.go
+++ b/src/store/preflight_data_store.go
@@ -68,7 +68,7 @@ func (s *preflightDataStore) LoadPreflightData(ctx context.Context, chainID, blo
 }
 
 func (s *preflightDataStore) path(chainID, blockNumber uint64) string {
-	return fmt.Sprintf("/%d/preflight/%d.json", chainID, blockNumber)
+	return fmt.Sprintf("/%d/%d/preflight.json", chainID, blockNumber)
 }
 
 type noOpPreflightDataStore struct{}

--- a/src/store/preflight_data_store_test.go
+++ b/src/store/preflight_data_store_test.go
@@ -40,7 +40,7 @@ func TestPreflightDataStore(t *testing.T) {
 	// Test storing and loading PreflightData
 	var dataCache []byte
 	ctx := context.TODO()
-	mockStore.EXPECT().Store(ctx, "/1/preflight/10.json", gomock.Any(), &store.Headers{
+	mockStore.EXPECT().Store(ctx, "/1/10/preflight.json", gomock.Any(), &store.Headers{
 		ContentType:     store.ContentTypeJSON,
 		ContentEncoding: store.ContentEncodingPlain,
 		KeyValue: map[string]string{
@@ -54,7 +54,7 @@ func TestPreflightDataStore(t *testing.T) {
 	err = preflightDataStore.StorePreflightData(ctx, preflightData)
 	assert.NoError(t, err)
 
-	mockStore.EXPECT().Load(ctx, "/1/preflight/10.json").Return(io.NopCloser(bytes.NewReader(dataCache)), nil, nil)
+	mockStore.EXPECT().Load(ctx, "/1/10/preflight.json").Return(io.NopCloser(bytes.NewReader(dataCache)), nil, nil)
 	loaded, err := preflightDataStore.LoadPreflightData(ctx, 1, 10)
 	assert.NoError(t, err)
 	assert.Equal(t, preflightData.ChainConfig.ChainID, loaded.ChainConfig.ChainID)


### PR DESCRIPTION
## 📝 Description

<!-- Provide a detailed description of your changes and the motivation behind them. -->

This PR updates the data store paths for prover input and preflight data. 

- Prover Input is now stored at `<data>/<chainId>/<blockNumber>/zkpi.<extension>` (e.g. `data/1/21655809/zkpi.json`)
- Preflight Data is now stored at `<data>/<chainId>/<blockNumber>/zkpi.<extension>` (e.g. `data/1/21655809/preflight.json`)

This facilites navigation as all files for a given block are stored under the same folder.

## ✅ Solved Issues

Resolves <!-- Provide references to the relevant issues, if applicable -->

## 🔄 Change

<!-- Tick the type of change introduced by this Pull Request: -->

- [ ] ✨ New feature (e.g. API route, major perf improvement...)
- [ ] 🐛 Bug fix
- [x] 🧹 Chore (e.g. package upgrades, configuration change, refactor, small perf improvement, typos...)
- [ ] 🧪 Tests
- [ ] 🏭 DevOps (e.g. CI-CD, development environment upgrade, security upgrade, automation addition...)
- [ ] 📚 Documentation

<!-- Tick if this Pull Request introduce a breaking change -->

- [x] 💥 Breaking Change

## 💥 Breaking Change (if applicable)

<!-- If this PR introduce breaking changes, describe them here, covering the migration path (e.g., API changes, configuration updates). -->

- Prover Input is now stored at `<data>/<chainId>/<blockNumber>/zkpi.<extension>` (e.g. `data/1/21655809/zkpi.json`)
- Preflight Data is now stored at `<data>/<chainId>/<blockNumber>/zkpi.<extension>` (e.g. `data/1/21655809/preflight.json`)

## 📋 Checklist

<!-- Confirm the following items are completed before submitting your pull request: -->

- [ ] I have added tests to cover my changes, if applicable.
- [ ] I have updated relevant documentation for my changes.
- [ ] I have included references to issues resolved by this Pull Request
- [ ] I have set a Pull Request title that respects [gitmoji](https://gitmoji.dev/)
- [ ] I have set a Pull Request's label to one of `type.feat`,`type.fix`,`type.chore`,`type.test`,`type.docs`,`type.devops`
- [ ] I have set a Pull Request's label to one of `breaking-change` or `non-breaking-change`
- [ ] I have documented breaking changes and migration path, if applicable

## 📓 Additional Notes

<!-- Include any additional context, considerations, or dependencies relevant to this pull request. -->
