### PR TITLE
Update GitHub Actions 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: fetch all tags

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup golang with the appropriate version
         uses: actions/setup-go@v5
         with:
@@ -58,7 +58,7 @@ jobs:
     if: github.ref != 'refs/heads/main'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup golang with the appropriate version
         uses: actions/setup-go@v5
         with:
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup golang with the appropriate version
         uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
Updates actions/checkout@v4 to actions/checkout@v5
Reference: https://github.com/actions/checkout/releases/tag/v5.0.0
